### PR TITLE
chronograf: Add support for Chronograf

### DIFF
--- a/playbooks/perftools-multi-hosts.yml
+++ b/playbooks/perftools-multi-hosts.yml
@@ -19,6 +19,12 @@
     - role: influxdb
   tags: influxdb
 
+- name: Install Chronograf
+  hosts: monitor
+  roles:
+    - role: kbrebanov.chronograf
+  tags: chronograf
+
 - name: Install Performance Co-Pilot
   hosts: hosts
   roles:

--- a/roles/roles_requirements.yml
+++ b/roles/roles_requirements.yml
@@ -9,3 +9,6 @@
 
 - src: git+https://github.com/vhe182/ansible-influxdb.git
   name: influxdb
+
+- src: git+https://github.com/kbrebanov/ansible-chronograf.git
+  name: kbrebanov.chronograf


### PR DESCRIPTION
Ansible support for Chronograf is now included in the
os-ansible-perftools.  Credit goes to kbrebranov for paving the way.  
The appropriate execution was added to the
playbook, as well as a tag for installing solely Chronograf.  That stuff is all me though :)
