### PR TITLE
Update performance lab ip addresses

### DIFF
--- a/iad3-performance-lab.ini
+++ b/iad3-performance-lab.ini
@@ -1,8 +1,8 @@
 [all]
 monitor01 ansible_ssh_host=10.240.0.72 ansible_ssh_user=root
-infra01 ansible_ssh_host=172.29.236.51 ansible_ssh_user=root
-infra02 ansible_ssh_host=172.29.236.52 ansible_ssh_user=root
-infra03 ansible_ssh_host=172.29.236.53 ansible_ssh_user=root
+infra01 ansible_ssh_host=10.240.0.68 ansible_ssh_user=root
+infra02 ansible_ssh_host=10.240.0.69 ansible_ssh_user=root
+infra03 ansible_ssh_host=10.240.0.70 ansible_ssh_user=root
 logging01 ansible_ssh_host=10.240.0.71 ansible_ssh_user=root
 compute001 ansible_ssh_host=10.240.0.73 ansible_ssh_user=root
 compute002 ansible_ssh_host=10.240.0.74 ansible_ssh_user=root
@@ -24,11 +24,11 @@ swiftstorage05 ansible_ssh_host=10.240.0.85 ansible_ssh_user=root
 cinder01 ansible_ssh_host=10.240.0.86 ansible_ssh_user=root
 cinder02 ansible_ssh_host=10.240.0.97 ansible_ssh_user=root
 cinder03 ansible_ssh_host=10.240.0.98 ansible_ssh_user=root
-cephstorage06 ansible_ssh_host=172.29.236.63 ansible_ssh_user=root
-cephstorage07 ansible_ssh_host=172.29.236.64 ansible_ssh_user=root
-cephstorage08 ansible_ssh_host=172.29.236.65 ansible_ssh_user=root
-cephstorage09 ansible_ssh_host=172.29.236.76 ansible_ssh_user=root
-cephstorage10 ansible_ssh_host=172.29.236.77 ansible_ssh_user=root
+cephstorage06 ansible_ssh_host=10.240.0.92  ansible_ssh_user=root
+cephstorage07 ansible_ssh_host=10.240.0.65 ansible_ssh_user=root
+cephstorage08 ansible_ssh_host=10.240.0.66 ansible_ssh_user=root
+cephstorage09 ansible_ssh_host=10.240.0.67 ansible_ssh_user=root
+cephstorage10 ansible_ssh_host=10.240.0.91 ansible_ssh_user=root
 infra01_ceph_mon_container ansible_ssh_host=172.29.238.41 ansible_ssh_user=root
 infra02_ceph_mon_container ansible_ssh_host=172.29.239.89 ansible_ssh_user=root
 infra03_ceph_mon_container ansible_ssh_host=172.29.238.135 ansible_ssh_user=root


### PR DESCRIPTION
After re-kick, we lost VLAN bridge.  It was recreated and the inventory
file is now updated to reflect the new ip addresses that were allotted.